### PR TITLE
Allow merging of Landscape and Portrait pages

### DIFF
--- a/src/iio/libmergepdf/Merger.php
+++ b/src/iio/libmergepdf/Merger.php
@@ -125,7 +125,8 @@ class Merger
                     for ($i=1; $i<=$iPageCount; $i++) {
                         $template = $fpdi->importPage($i);
                         $size = $fpdi->getTemplateSize($template);
-                        $fpdi->AddPage('P', array($size['w'], $size['h']));
+                        $orientation = ($size['w'] > $size['h']) ? 'L' : 'P';
+                        $fpdi->AddPage($orientation, array($size['w'], $size['h']));
                         $fpdi->useTemplate($template);
                     }
                 } else {
@@ -133,7 +134,8 @@ class Merger
                     foreach ($pages as $page) {
                         $template = $fpdi->importPage($page);
                         $size = $fpdi->getTemplateSize($template);
-                        $fpdi->AddPage('P', array($size['w'], $size['h']));
+                        $orientation = ($size['w'] > $size['h']) ? 'L' : 'P';
+                        $fpdi->AddPage($orientation, array($size['w'], $size['h']));
                         $fpdi->useTemplate($template);
                     }
                 }


### PR DESCRIPTION
- Merged pages defaulted to Portrait. This would cut off the right edge
  of a landscape page.
- Changed `merge()` to use the template sizes to guess wether the page
  is a landscape or portrait and set params in $fpdi->AddPage()
  appropriately.
