### PR TITLE
Close file handlers before cleanup temporary files

### DIFF
--- a/src/Merger.php
+++ b/src/Merger.php
@@ -158,15 +158,18 @@ class Merger
                     $fpdi->AddPage($orientation, array($size['w'], $size['h']));
                     $fpdi->useTemplate($template);
                 }
-
-                if ($cleanup) {
-                    unlink($fname);
-                }
             }
 
+            $output = $fpdi->Output('', 'S');
+
+            $fpdi->cleanUp();
+            foreach ($this->files as $fileData) {
+                list($fname, $pages, $cleanup) = $fileData;
+                if ($cleanup) unlink($fname);
+            }
             $this->files = array();
 
-            return $fpdi->Output('', 'S');
+            return $output;
 
         } catch (RuntimeException $e) {
             throw new Exception("FPDI: '{$e->getMessage()}' in '$fname'", 0, $e);


### PR DESCRIPTION
Fix a "permission denied" problem when the merger try to unlink a temp file, because the file should not be closed properly.

I found this issue on a WAMP server (no problem on a linux server). So I suggest to use the FPDI [cleanUp() method](http://manuals.setasign.com/fpdi-manual/the-fpdi-class/#index-3-5) before trying to delete the files.


