### PR TITLE
+silently failable sources in merge driver

### DIFF
--- a/src/Driver/DefaultDriver.php
+++ b/src/Driver/DefaultDriver.php
@@ -22,4 +22,8 @@ final class DefaultDriver implements DriverInterface
     {
         return $this->wrapped->merge(...$sources);
     }
+
+    public function getFailedSources(): array {
+        return $this->wrapped->getFailedSources();
+    }
 }

--- a/src/Driver/DriverInterface.php
+++ b/src/Driver/DriverInterface.php
@@ -10,4 +10,9 @@ interface DriverInterface
      * Merge multiple sources
      */
     public function merge(SourceInterface ...$sources): string;
+
+    /**
+     * Get the Sources that didn't merge
+     */
+    public function getFailedSources(): array;
 }


### PR DESCRIPTION
Let merge() merge as many sources as possible, but don't break when a merge breaks. Technically, that means moving the try/catch inside the `foreach ($sources)` and don't rethrow exceptions. And then after the foreach maybe throw if any failed. I didn't do that last bit, because lots of driver changes.

I could just make my own driver with this change, but then I have to hard choose a driver class (`Fpdi` vs `TCPDI`) and copy its code to do this, instead of reusing libmergepdf's merge logic.