### PR TITLE
Added option to add blank pages to support duplex printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ $merger->addFile('bar.pdf', new Pages('1-10'));
 $createdPdf = $merger->merge();
 ```
 
+Merge **foo.pdf** with **bar.pdf** and add a blank page to **foo.pdf** when it contains an uneven number of pages to support duplex printing:
+
+```php
+use iio\libmergepdf\Merger;
+use iio\libmergepdf\Pages;
+
+$merger = new Merger;
+$merger->addFile('foo.pdf', null, true);
+$merger->addFile('bar.pdf');
+$createdPdf = $merger->merge();
+```
+
 Bulk add files from an iterator:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ $merger->addFile('bar.pdf', new Pages('1-10'));
 $createdPdf = $merger->merge();
 ```
 
-Merge **foo.pdf** with **bar.pdf** and add a blank page to **foo.pdf** when it contains an uneven number of pages to support duplex printing:
+Merge **foo.pdf** with **bar.pdf** and add a blank page if necessary to ensure **bar.pdf** starts on the front of the page when printing in duplex:
 
 ```php
 use iio\libmergepdf\Merger;
 use iio\libmergepdf\Pages;
 
 $merger = new Merger;
-$merger->addFile('foo.pdf', null, true);
-$merger->addFile('bar.pdf');
+$merger->addFile('foo.pdf');
+$merger->addFile('bar.pdf', null, true);
 $createdPdf = $merger->merge();
 ```
 

--- a/src/Driver/Fpdi2Driver.php
+++ b/src/Driver/Fpdi2Driver.php
@@ -43,6 +43,10 @@ final class Fpdi2Driver implements DriverInterface
                 $pageCount = $fpdi->setSourceFile(StreamReader::createByString($source->getContents()));
                 $pageNumbers = $source->getPages()->getPageNumbers() ?: range(1, $pageCount);
 
+                if (isset($size) && $source->getDuplex() && $fpdi->PageNo() % 2 !== 0) {
+                    $fpdi->AddPage($size['width'] > $size['height'] ? 'L' : 'P', [$size['width'], $size['height']]);
+                }
+
                 foreach ($pageNumbers as $pageNr) {
                     $template = $fpdi->importPage($pageNr);
                     $size = $fpdi->getTemplateSize($template);
@@ -53,10 +57,6 @@ final class Fpdi2Driver implements DriverInterface
                         [$size['width'], $size['height']]
                     );
                     $fpdi->useTemplate($template);
-                }
-
-                if ($source->getDuplex() && $fpdi->PageNo() % 2 !== 0) {
-                    $fpdi->AddPage($size['width'] > $size['height'] ? 'L' : 'P', [$size['width'], $size['height']]);
                 }
             }
 

--- a/src/Driver/Fpdi2Driver.php
+++ b/src/Driver/Fpdi2Driver.php
@@ -54,6 +54,10 @@ final class Fpdi2Driver implements DriverInterface
                     );
                     $fpdi->useTemplate($template);
                 }
+
+                if ($source->getDuplex() && $fpdi->PageNo() % 2 !== 0) {
+                    $fpdi->AddPage($size['width'] > $size['height'] ? 'L' : 'P', [$size['width'], $size['height']]);
+                }
             }
 
             return $fpdi->Output('', 'S');

--- a/src/Driver/TcpdiDriver.php
+++ b/src/Driver/TcpdiDriver.php
@@ -42,6 +42,10 @@ final class TcpdiDriver implements DriverInterface
                     );
                     $tcpdi->useTemplate($template);
                 }
+
+                if ($source->getDuplex() && $tcpdi->PageNo() % 2 !== 0) {
+                    $tcpdi->AddPage($size['w'] > $size['h'] ? 'L' : 'P', [$size['w'], $size['h']]);
+                }
             }
 
             return $tcpdi->Output('', 'S');

--- a/src/Driver/TcpdiDriver.php
+++ b/src/Driver/TcpdiDriver.php
@@ -31,6 +31,10 @@ final class TcpdiDriver implements DriverInterface
                 $pageCount = $tcpdi->setSourceData($source->getContents());
                 $pageNumbers = $source->getPages()->getPageNumbers() ?: range(1, $pageCount);
 
+                if (isset($size) && $source->getDuplex() && $tcpdi->PageNo() % 2 !== 0) {
+                    $tcpdi->AddPage($size['w'] > $size['h'] ? 'L' : 'P', [$size['w'], $size['h']]);
+                }
+
                 foreach ($pageNumbers as $pageNr) {
                     $template = $tcpdi->importPage($pageNr);
                     $size = $tcpdi->getTemplateSize($template);
@@ -41,10 +45,6 @@ final class TcpdiDriver implements DriverInterface
                         [$size['w'], $size['h']]
                     );
                     $tcpdi->useTemplate($template);
-                }
-
-                if ($source->getDuplex() && $tcpdi->PageNo() % 2 !== 0) {
-                    $tcpdi->AddPage($size['w'] > $size['h'] ? 'L' : 'P', [$size['w'], $size['h']]);
                 }
             }
 

--- a/src/Merger.php
+++ b/src/Merger.php
@@ -35,17 +35,17 @@ final class Merger
     /**
      * Add raw PDF from string
      */
-    public function addRaw(string $content, PagesInterface $pages = null): void
+    public function addRaw(string $content, PagesInterface $pages = null, bool $duplex = false): void
     {
-        $this->sources[] = new RawSource($content, $pages);
+        $this->sources[] = new RawSource($content, $pages, $duplex);
     }
 
     /**
      * Add PDF from file
      */
-    public function addFile(string $filename, PagesInterface $pages = null): void
+    public function addFile(string $filename, PagesInterface $pages = null, bool $duplex = false): void
     {
-        $this->sources[] = new FileSource($filename, $pages);
+        $this->sources[] = new FileSource($filename, $pages, $duplex);
     }
 
     /**
@@ -54,10 +54,10 @@ final class Merger
      * @param iterable<string> $iterator Set of filenames to add
      * @param PagesInterface $pages Optional pages constraint used for every added pdf
      */
-    public function addIterator(iterable $iterator, PagesInterface $pages = null): void
+    public function addIterator(iterable $iterator, PagesInterface $pages = null, bool $duplex = false): void
     {
         foreach ($iterator as $filename) {
-            $this->addFile($filename, $pages);
+            $this->addFile($filename, $pages, $duplex);
         }
     }
 

--- a/src/Source/FileSource.php
+++ b/src/Source/FileSource.php
@@ -23,7 +23,12 @@ final class FileSource implements SourceInterface
      */
     private $pages;
 
-    public function __construct(string $filename, PagesInterface $pages = null)
+    /**
+     * @var bool
+     */
+    private $duplex;
+
+    public function __construct(string $filename, PagesInterface $pages = null, bool $duplex = false)
     {
         if (!is_file($filename) || !is_readable($filename)) {
             throw new Exception("Invalid file '$filename'");
@@ -31,6 +36,7 @@ final class FileSource implements SourceInterface
 
         $this->filename = $filename;
         $this->pages = $pages ?: new Pages;
+        $this->duplex = $duplex;
     }
 
     public function getName(): string
@@ -46,5 +52,10 @@ final class FileSource implements SourceInterface
     public function getPages(): PagesInterface
     {
         return $this->pages;
+    }
+
+    public function getDuplex(): bool
+    {
+        return $this->duplex;
     }
 }

--- a/src/Source/RawSource.php
+++ b/src/Source/RawSource.php
@@ -22,10 +22,16 @@ final class RawSource implements SourceInterface
      */
     private $pages;
 
-    public function __construct(string $contents, PagesInterface $pages = null)
+    /**
+     * @var bool
+     */
+    private $duplex;
+
+    public function __construct(string $contents, PagesInterface $pages = null, bool $duplex = false)
     {
         $this->contents = $contents;
         $this->pages = $pages ?: new Pages;
+        $this->duplex = $duplex;
     }
 
     public function getName(): string
@@ -41,5 +47,10 @@ final class RawSource implements SourceInterface
     public function getPages(): PagesInterface
     {
         return $this->pages;
+    }
+
+    public function getDuplex(): bool
+    {
+        return $this->duplex;
     }
 }

--- a/src/Source/SourceInterface.php
+++ b/src/Source/SourceInterface.php
@@ -22,4 +22,9 @@ interface SourceInterface
      * Get pages to fetch from source
      */
     public function getPages(): PagesInterface;
+
+    /**
+     * Get duplex printing
+     */
+    public function getDuplex(): bool;
 }

--- a/tests/Driver/Fpdi2DriverTest.php
+++ b/tests/Driver/Fpdi2DriverTest.php
@@ -61,6 +61,7 @@ class Fpdi2DriverTest extends \PHPUnit\Framework\TestCase
         $source->getName()->willReturn('');
         $source->getContents()->willReturn('');
         $source->getPages()->willReturn(new Pages('1, 2'));
+        $source->getDuplex()->willReturn(false);
 
         $this->assertSame(
             'created-pdf',

--- a/tests/Driver/TcpdiDriverTest.php
+++ b/tests/Driver/TcpdiDriverTest.php
@@ -50,6 +50,7 @@ class TcpdiDriverTest extends \PHPUnit\Framework\TestCase
         $source->getName()->willReturn('');
         $source->getContents()->willReturn('data');
         $source->getPages()->willReturn(new Pages('1, 2'));
+        $source->getDuplex()->willReturn(false);
 
         $this->assertSame(
             'created-pdf',

--- a/tests/Source/FileSourceTest.php
+++ b/tests/Source/FileSourceTest.php
@@ -39,4 +39,12 @@ class FileSourceTest extends \PHPUnit\Framework\TestCase
             (new FileSource(__FILE__, $pages))->getPages()
         );
     }
+
+    public function testGetDuplex()
+    {
+        $this->assertSame(
+            true,
+            (new FileSource(__FILE__, null, true))->getDuplex()
+        );
+    }
 }

--- a/tests/Source/RawSourceTest.php
+++ b/tests/Source/RawSourceTest.php
@@ -32,4 +32,12 @@ class RawSourceTest extends \PHPUnit\Framework\TestCase
             (new RawSource('', $pages))->getPages()
         );
     }
+
+    public function testGetDuplex()
+    {
+        $this->assertSame(
+            true,
+            (new RawSource(__FILE__, null, true))->getDuplex()
+        );
+    }
 }


### PR DESCRIPTION
Hello! Thank you for this library, it is very useful for merging PDF's.

Some of the documents I merge are printed double sided and I was having the problem that some attachments where printing on the back of the letter. So I added a duplex option when adding files. When this option is set to true a blank page is inserted to ensure the document starts at an even page count.

Thanks!