### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/src/Driver/DefaultDriver.php
+++ b/src/Driver/DefaultDriver.php
@@ -13,7 +13,7 @@ final class DefaultDriver implements DriverInterface
      */
     private $wrapped;
 
-    public function __construct(DriverInterface $wrapped = null)
+    public function __construct(?DriverInterface $wrapped = null)
     {
         $this->wrapped = $wrapped ?: new Fpdi2Driver;
     }

--- a/src/Driver/TcpdiDriver.php
+++ b/src/Driver/TcpdiDriver.php
@@ -14,7 +14,7 @@ final class TcpdiDriver implements DriverInterface
      */
     private $tcpdi;
 
-    public function __construct(\TCPDI $tcpdi = null)
+    public function __construct(?\TCPDI $tcpdi = null)
     {
         $this->tcpdi = $tcpdi ?: new \TCPDI;
     }

--- a/src/Merger.php
+++ b/src/Merger.php
@@ -27,7 +27,7 @@ final class Merger
      */
     private $driver;
 
-    public function __construct(DriverInterface $driver = null)
+    public function __construct(?DriverInterface $driver = null)
     {
         $this->driver = $driver ?: new DefaultDriver;
     }
@@ -35,7 +35,7 @@ final class Merger
     /**
      * Add raw PDF from string
      */
-    public function addRaw(string $content, PagesInterface $pages = null): void
+    public function addRaw(string $content, ?PagesInterface $pages = null): void
     {
         $this->sources[] = new RawSource($content, $pages);
     }
@@ -43,7 +43,7 @@ final class Merger
     /**
      * Add PDF from file
      */
-    public function addFile(string $filename, PagesInterface $pages = null): void
+    public function addFile(string $filename, ?PagesInterface $pages = null): void
     {
         $this->sources[] = new FileSource($filename, $pages);
     }
@@ -54,7 +54,7 @@ final class Merger
      * @param iterable<string> $iterator Set of filenames to add
      * @param PagesInterface $pages Optional pages constraint used for every added pdf
      */
-    public function addIterator(iterable $iterator, PagesInterface $pages = null): void
+    public function addIterator(iterable $iterator, ?PagesInterface $pages = null): void
     {
         foreach ($iterator as $filename) {
             $this->addFile($filename, $pages);

--- a/src/Source/FileSource.php
+++ b/src/Source/FileSource.php
@@ -23,7 +23,7 @@ final class FileSource implements SourceInterface
      */
     private $pages;
 
-    public function __construct(string $filename, PagesInterface $pages = null)
+    public function __construct(string $filename, ?PagesInterface $pages = null)
     {
         if (!is_file($filename) || !is_readable($filename)) {
             throw new Exception("Invalid file '$filename'");

--- a/src/Source/RawSource.php
+++ b/src/Source/RawSource.php
@@ -22,7 +22,7 @@ final class RawSource implements SourceInterface
      */
     private $pages;
 
-    public function __construct(string $contents, PagesInterface $pages = null)
+    public function __construct(string $contents, ?PagesInterface $pages = null)
     {
         $this->contents = $contents;
         $this->pages = $pages ?: new Pages;


### PR DESCRIPTION
Implicitly nullable function parameters are deprecated in PHP 8.4:
* https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter

The nullable `?Type` syntax was added in PHP 7.1, which is the lowest version supported by this library according to `composer.json`:
* https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.nullable-types